### PR TITLE
Fix workflow errors

### DIFF
--- a/.github/workflows/aishell.yml
+++ b/.github/workflows/aishell.yml
@@ -33,7 +33,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   aishell:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}

--- a/.github/workflows/audioset.yml
+++ b/.github/workflows/audioset.yml
@@ -32,7 +32,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
   audioset:
     needs: generate_build_matrix
@@ -134,4 +134,3 @@ jobs:
           repo_name: k2-fsa/sherpa-onnx
           repo_token: ${{ secrets.UPLOAD_GH_SHERPA_ONNX_TOKEN }}
           tag: audio-tagging-models
-

--- a/.github/workflows/baker_zh.yml
+++ b/.github/workflows/baker_zh.yml
@@ -33,7 +33,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py --min-torch-version "2.3"
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --min-torch-version "2.3")
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
   baker_zh:
     needs: generate_build_matrix

--- a/.github/workflows/build-cpu-docker.yml
+++ b/.github/workflows/build-cpu-docker.yml
@@ -23,7 +23,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   build-cpu-docker:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -43,12 +43,12 @@ jobs:
         python-version: ["3.8"]
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ksponspeech.yml
+++ b/.github/workflows/ksponspeech.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/librispeech.yml
+++ b/.github/workflows/librispeech.yml
@@ -31,7 +31,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   librispeech:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}

--- a/.github/workflows/ljspeech.yml
+++ b/.github/workflows/ljspeech.yml
@@ -32,7 +32,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py --min-torch-version "2.3"
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --min-torch-version "2.3")
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
   ljspeech:
     needs: generate_build_matrix

--- a/.github/workflows/multi-zh-hans.yml
+++ b/.github/workflows/multi-zh-hans.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/rknn.yml
+++ b/.github/workflows/rknn.yml
@@ -33,7 +33,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py --torch-version=2.4.0 --python-version=3.10
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py --torch-version=2.4.0 --python-version=3.10)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   rknn:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}

--- a/.github/workflows/run-docker-image.yml
+++ b/.github/workflows/run-docker-image.yml
@@ -17,7 +17,7 @@ jobs:
         image: ["torch2.4.0-cuda12.4", "torch2.4.0-cuda12.1", "torch2.4.0-cuda11.8", "torch2.3.1-cuda12.1", "torch2.3.1-cuda11.8", "torch2.2.2-cuda12.1", "torch2.2.2-cuda11.8", "torch2.2.1-cuda12.1", "torch2.2.1-cuda11.8", "torch2.2.0-cuda12.1", "torch2.2.0-cuda11.8", "torch2.1.0-cuda12.1", "torch2.1.0-cuda11.8", "torch2.0.0-cuda11.7", "torch1.13.0-cuda11.6", "torch1.12.1-cuda11.3", "torch1.9.0-cuda10.2"]
     steps:
       # refer to https://github.com/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/run-gigaspeech-2022-05-13.yml
+++ b/.github/workflows/run-gigaspeech-2022-05-13.yml
@@ -51,12 +51,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
+++ b/.github/workflows/run-gigaspeech-zipformer-2023-10-17.yml
@@ -52,12 +52,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
+++ b/.github/workflows/run-librispeech-lstm-transducer-stateless2-2022-09-03.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache LibriSpeech test-clean and test-other datasets
         id: libri-test-clean-and-test-other-data
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/download
@@ -86,7 +86,7 @@ jobs:
 
       - name: Cache LibriSpeech test-clean and test-other fbank features
         id: libri-test-clean-and-test-other-fbank
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/fbank-libri

--- a/.github/workflows/run-multi-corpora-zipformer.yml
+++ b/.github/workflows/run-multi-corpora-zipformer.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-ptb-rnn-lm.yml
+++ b/.github/workflows/run-ptb-rnn-lm.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/run-swbd-conformer-ctc.yml
+++ b/.github/workflows/run-swbd-conformer-ctc.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
+++ b/.github/workflows/run-wenetspeech-pruned-transducer-stateless2.yml
@@ -41,12 +41,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -40,12 +40,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-ncnn-export.yml
+++ b/.github/workflows/test-ncnn-export.yml
@@ -33,12 +33,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/test-onnx-export.yml
+++ b/.github/workflows/test-onnx-export.yml
@@ -33,12 +33,12 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache kaldifeat
         id: my-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/tmp/kaldifeat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   test:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}

--- a/.github/workflows/yesno.yml
+++ b/.github/workflows/yesno.yml
@@ -32,7 +32,7 @@ jobs:
           # outputting for debugging purposes
           python ./.github/scripts/docker/generate_build_matrix.py
           MATRIX=$(python ./.github/scripts/docker/generate_build_matrix.py)
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
   yesno:
     needs: generate_build_matrix
     name: py${{ matrix.python-version }} torch${{ matrix.torch-version }} v${{ matrix.version }}


### PR DESCRIPTION
## Summary
- use latest checkout and setup-python actions
- replace deprecated set-output syntax with GITHUB_OUTPUT
- bump cache action version

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}' | tr '\n' ' ')`
- `pytest -q` *(fails: Fatal Python error)*

------
https://chatgpt.com/codex/tasks/task_e_683fb43ea7d4833088adb3d821eb68d9